### PR TITLE
Avoid hitting the same buildtype multiple times

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     testImplementation (platform("org.junit:junit-bom:5.4.2"))
     testImplementation ("org.junit.jupiter:junit-jupiter-api")
-    testImplementation ("org.mockito:mockito-core:2.7.22")
+    testImplementation ("org.mockito:mockito-core:2.22.0")
 
     testRuntimeOnly ("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.github.rodm"
-version = "0.6"
+version = "0.7"
 
 extra["teamcityVersion"] = findProperty("teamcity.api.version") as String? ?: "2019.1"
 

--- a/src/main/kotlin/com/github/rodm/teamcity/usage/ParameterSearch.kt
+++ b/src/main/kotlin/com/github/rodm/teamcity/usage/ParameterSearch.kt
@@ -89,7 +89,7 @@ class ParameterSearch(parameter: String, private val project: SProject) {
                 results.add(result)
             }
         }
-        project.buildTypes.forEach { buildType ->
+        project.ownBuildTypes.forEach { buildType ->
             val result = SearchResult(buildType.externalId, buildType.fullName)
             buildType.ownOptions.forEach { option ->
                 val optionValue = buildType.getOption(option).toString()

--- a/src/main/kotlin/com/github/rodm/teamcity/usage/ParameterUsagePage.kt
+++ b/src/main/kotlin/com/github/rodm/teamcity/usage/ParameterUsagePage.kt
@@ -19,6 +19,7 @@ package com.github.rodm.teamcity.usage
 import jetbrains.buildServer.controllers.admin.projects.EditProjectTab
 import jetbrains.buildServer.web.openapi.PagePlaces
 import jetbrains.buildServer.web.openapi.PluginDescriptor
+import jetbrains.buildServer.web.openapi.PositionConstraint
 
 class ParameterUsagePage(pagePlaces: PagePlaces,
                          descriptor: PluginDescriptor) :
@@ -27,5 +28,8 @@ class ParameterUsagePage(pagePlaces: PagePlaces,
     init {
         addJsFile(descriptor.getPluginResourcesPath("usage.js"))
         addCssFile(descriptor.getPluginResourcesPath("usage.css"))
+        //setPosition(PositionConstraint.after("projectParams"))
+        setPosition(PositionConstraint.last())
+
     }
 }

--- a/src/main/resources/buildServerResources/usagePage.jsp
+++ b/src/main/resources/buildServerResources/usagePage.jsp
@@ -38,7 +38,7 @@
              onclick="return BS.UsageSearch.search('${currentProject.externalId}');"/>
 
       <div id="paramNameError" class="error" style="display: none;">
-        A parameter name must be specified and be a least 2 characters long
+        A parameter name must be specified and be at least 2 characters long
       </div>
     </div>
   </div>

--- a/src/test/kotlin/com/github/rodm/teamcity/usage/BuildTemplateParameterSearchTest.kt
+++ b/src/test/kotlin/com/github/rodm/teamcity/usage/BuildTemplateParameterSearchTest.kt
@@ -78,7 +78,7 @@ class BuildTemplateParameterSearchTest {
         assertThat(matches, hasSize(1))
         assertThat(matches[0], equalTo(searchResult(buildTemplate)))
     }
-    
+
     @Test
     fun `search for parameter returns result with matching names`() {
         val buildTemplate = buildTemplate().withOwnParameters(mapOf("param1" to "%parameter1%", "param2" to "%prop2% %param3%"))
@@ -91,7 +91,7 @@ class BuildTemplateParameterSearchTest {
         assertThat(matches[0], equalTo(searchResult(buildTemplate)))
         assertThat(matches[0].namesBySection["Parameters"], containsInAnyOrder(equalTo("parameter1"), equalTo("param3")))
     }
-    
+
     @Test
     fun `search for parameter returns build template when found in build steps`() {
         val buildTemplate = buildTemplate()

--- a/src/test/kotlin/com/github/rodm/teamcity/usage/BuildTypeParameterSearchTest.kt
+++ b/src/test/kotlin/com/github/rodm/teamcity/usage/BuildTypeParameterSearchTest.kt
@@ -29,7 +29,7 @@ class BuildTypeParameterSearchTest {
     @Test
     fun `search for parameter not referenced by a build configuration returns no matches`() {
         val buildType = buildType().withOwnParameters(mapOf("param1" to "value1"))
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -41,7 +41,7 @@ class BuildTypeParameterSearchTest {
     @Test
     fun `search for parameter referenced by a build configuration returns matched build type`() {
         val buildType = buildType().withOwnParameters(mapOf("param1" to "%parameter%"))
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -56,7 +56,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter referenced by a build configuration thru inheritance returns no matches`() {
         val buildType = buildType()
         buildType.setParameters(mapOf("param1" to "%parameter%"))
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -68,7 +68,7 @@ class BuildTypeParameterSearchTest {
     @Test
     fun `search for parameter referenced by a build configuration in a subproject`() {
         val buildType = buildType().withOwnParameters(mapOf("param1" to "%parameter%"))
-        val subProject = project().withBuildType(buildType)
+        val subProject = project().withOwnBuildType(buildType)
         val project = project().withSubProject(subProject)
 
         val searchFor = "parameter"
@@ -82,7 +82,7 @@ class BuildTypeParameterSearchTest {
     @Test
     fun `search for parameter returns result with matching names`() {
         val buildType = buildType().withOwnParameters(mapOf("param1" to "%parameter1%", "param2" to "%prop2% %param3%"))
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "param"
         val searcher = ParameterSearch(searchFor, project)
@@ -91,12 +91,12 @@ class BuildTypeParameterSearchTest {
         assertThat(matches[0], equalTo(searchResult(buildType)))
         assertThat(matches[0].namesBySection["Parameters"], containsInAnyOrder(equalTo("parameter1"), equalTo("param3")))
     }
-    
+
     @Test
     fun `search for parameter returns build configuration when found in build steps`() {
         val buildType = buildType()
         buildType.addBuildRunner("name", "type", mutableMapOf("param1" to "%parameter%"))
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -111,7 +111,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter returns no matches when not found in build steps`() {
         val buildType = buildType()
         buildType.addBuildRunner("name", "type", mutableMapOf("param1" to "value1"))
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -124,7 +124,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter returns build configuration when found in a build feature`() {
         val feature = buildFeature().withParameters(mapOf("param1" to "%parameter%"))
         val buildType = buildType().withBuildFeature(feature)
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -139,7 +139,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter returns build configuration when found in a failure condition`() {
         val failureCondition = failureCondition().withParameters(mapOf("param1" to "%parameter%"))
         val buildType = buildType().withFailureCondition(failureCondition)
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -154,7 +154,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter returns build configuration when found in agent requirements`() {
         val requirement = requirement("param", "%parameter%")
         val buildType = buildType().withRequirement(requirement)
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -168,7 +168,7 @@ class BuildTypeParameterSearchTest {
     @Test
     fun `search for parameter returns build configuration when found in general settings`() {
         val buildType = buildType().withOption("name", "%parameter%")
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -185,7 +185,7 @@ class BuildTypeParameterSearchTest {
             .withOption("name", "%parameter1%")
             .withOption(BT_BRANCH_FILTER.key, "%parameter2%")
             .withOption(BT_CHECKOUT_DIR.key, "%parameter3%")
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -201,7 +201,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter returns build configuration when found in a dependency`() {
         val dependency = dependency().withOption("name", "%parameter%")
         val buildType = buildType().withDependency(dependency)
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)
@@ -216,7 +216,7 @@ class BuildTypeParameterSearchTest {
     fun `search for parameter returns build configuration when found in an artifact dependency`() {
         val dependency = artifactDependency().withSourcePaths("%paths.parameter%")
         val buildType = buildType().withArtifactDependency(dependency)
-        val project = project().withBuildType(buildType)
+        val project = project().withOwnBuildType(buildType)
 
         val searchFor = "parameter"
         val searcher = ParameterSearch(searchFor, project)

--- a/src/test/kotlin/com/github/rodm/teamcity/usage/Util.kt
+++ b/src/test/kotlin/com/github/rodm/teamcity/usage/Util.kt
@@ -60,14 +60,14 @@ fun artifactDependency(): FakeArtifactDependency = FakeArtifactDependency()
 class FakeProject: SProject by Mockito.mock(SProject::class.java) {
 
     private val subProjects = mutableListOf<SProject>()
-    private val buildTypes: MutableList<SBuildType> = mutableListOf()
+    private val ownBuildTypes: MutableList<SBuildType> = mutableListOf()
     private val ownBuildTemplates = mutableListOf<BuildTypeTemplate>()
     private val ownParams: MutableMap<String, String> = mutableMapOf()
 
     override fun getExternalId(): String = "projectId"
     override fun getFullName(): String = "project name"
     override fun getOwnProjects(): MutableList<SProject> = subProjects
-    override fun getBuildTypes(): MutableList<SBuildType> = buildTypes
+    override fun getOwnBuildTypes(): MutableList<SBuildType> = ownBuildTypes
     override fun getOwnBuildTypeTemplates(): MutableList<BuildTypeTemplate> = ownBuildTemplates
     override fun getOwnParameters(): MutableMap<String, String> = ownParams
 
@@ -76,8 +76,8 @@ class FakeProject: SProject by Mockito.mock(SProject::class.java) {
         return this
     }
 
-    fun withBuildType(buildType: SBuildType): FakeProject {
-        buildTypes.add(buildType)
+    fun withOwnBuildType(buildType: SBuildType): FakeProject {
+        ownBuildTypes.add(buildType)
         return this
     }
 
@@ -150,7 +150,7 @@ class FakeBuildType: SBuildType by Mockito.mock(SBuildType::class.java) {
     }
 
     override fun getArtifactDependencies(): MutableList<SArtifactDependency> = artifactDependencies
-    
+
     fun setParameters(parameters: Map<String, String>) {
         params.clear()
         params.putAll(parameters)


### PR DESCRIPTION
When processing a project with subprojects, the iteration on `project.buildTypes` will find not only the builds of this parent project, but also the builds of the subprojects. A build is therefore listed multiple types on the output page. Better to use `project.ownBuildTypes`